### PR TITLE
fix: load language files when used as mu-plugin

### DIFF
--- a/municipio-gatsby.php
+++ b/municipio-gatsby.php
@@ -12,10 +12,17 @@
 define("MUNICIPIO_GATSBY_PLUGIN_FILE", __FILE__);
 define("MUNICIPIO_GATSBY_PATH", dirname(__FILE__));
 define("MUNICIPIO_GATSBY_AUTOLOAD_PATH", MUNICIPIO_GATSBY_PATH . "/autoload");
-define("MUNICIPIO_GATSBY_LANGUAGES_PATH", plugin_basename(dirname(__FILE__)) . "/languages");
+define(
+  "MUNICIPIO_GATSBY_LANGUAGES_PATH",
+  plugin_basename(dirname(__FILE__)) . "/languages"
+);
 
 add_action("plugins_loaded", function () {
-  load_plugin_textdomain("municipio-gatsby", false, MUNICIPIO_GATSBY_LANGUAGES_PATH);
+  load_plugin_textdomain(
+    "municipio-gatsby",
+    false,
+    MUNICIPIO_GATSBY_LANGUAGES_PATH
+  );
 });
 
 add_action("muplugins_loaded", function () {

--- a/municipio-gatsby.php
+++ b/municipio-gatsby.php
@@ -12,15 +12,15 @@
 define("MUNICIPIO_GATSBY_PLUGIN_FILE", __FILE__);
 define("MUNICIPIO_GATSBY_PATH", dirname(__FILE__));
 define("MUNICIPIO_GATSBY_AUTOLOAD_PATH", MUNICIPIO_GATSBY_PATH . "/autoload");
+define("MUNICIPIO_GATSBY_LANGUAGES_PATH", plugin_basename(dirname(__FILE__)) . "/languages");
 
-function municipio_gatsby_load_languages() {
-  $path = plugin_basename(dirname(__FILE__)) . "/languages";
-  load_plugin_textdomain("municipio-gatsby", false, $path);
-  load_muplugin_textdomain("municipio-gatsby", $path);
-}
+add_action("plugins_loaded", function () {
+  load_plugin_textdomain("municipio-gatsby", false, MUNICIPIO_GATSBY_LANGUAGES_PATH);
+});
 
-add_action("plugins_loaded", "municipio_gatsby_load_languages");
-add_action("muplugins_loaded", "municipio_gatsby_load_languages");
+add_action("muplugins_loaded", function () {
+  load_muplugin_textdomain("municipio-gatsby", MUNICIPIO_GATSBY_LANGUAGES_PATH);
+});
 
 array_map(static function () {
   include_once func_get_args()[0];

--- a/municipio-gatsby.php
+++ b/municipio-gatsby.php
@@ -13,11 +13,14 @@ define("MUNICIPIO_GATSBY_PLUGIN_FILE", __FILE__);
 define("MUNICIPIO_GATSBY_PATH", dirname(__FILE__));
 define("MUNICIPIO_GATSBY_AUTOLOAD_PATH", MUNICIPIO_GATSBY_PATH . "/autoload");
 
-add_action("init", function () {
+function municipio_gatsby_load_languages() {
   $path = plugin_basename(dirname(__FILE__)) . "/languages";
   load_plugin_textdomain("municipio-gatsby", false, $path);
   load_muplugin_textdomain("municipio-gatsby", $path);
-});
+}
+
+add_action("plugins_loaded", "municipio_gatsby_load_languages");
+add_action("muplugins_loaded", "municipio_gatsby_load_languages");
 
 array_map(static function () {
   include_once func_get_args()[0];


### PR DESCRIPTION
Textdomain language files are not loaded when this plugin is used as a mu-plugin. This solves it by changing the action hook from `init` to both `plugins_loaded` and `muplugins_loaded`.